### PR TITLE
Accessibility Fix

### DIFF
--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -202,17 +202,26 @@ function ParagraphElement (props) {
         const _accViews = [];
         /// We are assuming that link is always contained in the concatenated string
         links.forEach((link, index) => {
-        const start = concatenated_string.indexOf(link.text);
-        const end = start + link.text.length - 1;
-        const sIdx = indexLte(cumulative_len, start);
-        const eIdx = indexLte(cumulative_len, end);
-        _accViews.push((
-            <Text key={"__Acc_View_rtb" + index} 
-                style={{height: lines[eIdx].y - lines[sIdx].y + lines[eIdx].height, width: lines[sIdx].width, position: 'absolute', top: 1+lines[sIdx].y, left: lines[sIdx].x}}
-                accessibilityLabel={link.text}
-                accessibilityRole='link'
-                accessible={true}
-                onPress={() => {link.onClick()}}>{' '}</Text>));
+            const start = concatenated_string.indexOf(link.text);
+            const end = start + link.text.length - 1;
+            const sIdx = indexLte(cumulative_len, start);
+            const eIdx = indexLte(cumulative_len, end);
+            const style = {height: lines[eIdx].y - lines[sIdx].y + lines[eIdx].height, width: lines[sIdx].width, position: 'absolute', top: 1+lines[sIdx].y, left: lines[sIdx].x};
+
+            // The link just spans a single line
+            // This is slightly inaccurate, because it assumes each character occupies the same width, but this is the best we can do.
+            if (sIdx === eIdx) {
+                style.left = lines[sIdx].x + (lines[sIdx].width * (start - cumulative_len[sIdx])/lines[sIdx].text.length);
+                style.width = lines[sIdx].width * (link.text.length)/lines[sIdx].text.length;
+            }
+
+            _accViews.push((
+                <Text key={"__Acc_View_rtb" + index} 
+                    style={style}
+                    accessibilityLabel={link.text}
+                    accessibilityRole='link'
+                    accessible={true}
+                    onPress={() => {link.onClick()}}>{' '}</Text>));
 
         });
         setAccContainers(_accViews);

--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -42,9 +42,7 @@ export class RichTextBlock extends React.Component {
         if (this.payload.paragraphs) {
             this.payload.paragraphs.forEach((paragraph, index) => {
                 paragraphElements.push(
-                    <Text key={"paragraph" + index} numberOfLines={numberOfLines}>
-                        {this.getTextRunElements(paragraph)}
-                    </Text >
+                    <ParagraphElement index={index} numberOfLines={numberOfLines} paragraph={paragraph} thisArg={this} />
                 );
             })
         }
@@ -96,12 +94,18 @@ export class RichTextBlock extends React.Component {
     /**
      * @description Return the TextRun element from the paragraph 
      * @param {object} paragraph - paragraph from the payload
+     * @param {object} setLinks - A function that is called with the complete list of links in this paragraph. Of type {text: string; onClick: () => void}[]
      * @returns {Array} TextRun elements
      */
-    getTextRunElements = (paragraph) => {
+    getTextRunElements = (paragraph, setLinks) => {
         var textRunElements = [];
+        var _links = [];
         paragraph.inlines && paragraph.inlines.forEach((textRun, index) => {
             if (textRun.type.toLowerCase() == Constants.TextRunString) {
+                if (textRun.selectAction) {
+                    _links.push({text: textRun.text, onClick: () => {this.onClickHandle(textRun.selectAction)}})
+                }
+
                 index > 0 && textRunElements.push(<Text key={"white-sapce-text" + index}>{" "}</Text>);
                 let textRunStyle = textRun.highlight ? [styles.text, { backgroundColor: this.props.configManager.hostConfig.richTextBlock.highlightColor }] : [styles.text];
                 textRun.underline && textRunStyle.push(styles.underlineStyle)
@@ -122,15 +126,12 @@ export class RichTextBlock extends React.Component {
                         />
                 );
             }
-        })
+        });
+        setLinks(_links);
         return textRunElements;
     }
 
     render() {
-        if (!this.payload.paragraphs) {
-            this.payload.paragraphs = [{"inlines": this.payload.inlines}];
-        }
-        
         return (<InputContextConsumer>
             {({ onExecuteAction }) => {
                 this.onExecuteAction = onExecuteAction;
@@ -156,3 +157,105 @@ const styles = StyleSheet.create({
 	}
 });
 
+/// props: {index: number, numberofLines: number, paragraph: the actual paragraph object, thisArg: 'this' of the parent RichTextBlock component}
+function ParagraphElement (props) {
+    /// Empty React components just for the purpose of providing screen reader focus to hyperlinks
+    /// These are positioned on the lines which contain links using absolute positioning.
+    const [accContainers, setAccContainers] = React.useState(undefined);
+    
+    /// Ref to List of links: Array of {text: string, onClick: () => void}
+    const _links = React.useRef([]);
+    /// Function to resolve the promise linksSetPromise
+    const _resolveLinksSetPromise = React.useRef(undefined);
+    /// Promise that is resolved once we have obtained the list of links.
+    const _linksSetPromise = React.useRef(undefined);
+
+    if(!_resolveLinksSetPromise.current) {
+        const linksSetPromise = new Promise(function(resolve, reject) {
+            _resolveLinksSetPromise.current = resolve;
+        });
+        _linksSetPromise.current = linksSetPromise;
+    }
+
+    function setLinks(links) {
+        _links.current = links;
+        _resolveLinksSetPromise.current();
+    }
+
+    /**
+     * Adds the accessibility containers - i.e. empty containers just for bringing screen reader focus.
+     * @param {*} lines - {text: string, width: number, height: number, y: number, x: number}[] Obtained from onTextLayout
+     * @param {*} links - {text: string, onClick: () => void}[] - Array of an object 
+     *  containing the string that was rendered as a link and the function to be called on click.
+     */
+    function addAccContainers(lines, links) {
+        // Stores cumulative length of the ith line (1-indexed -> arr[1] means cumulative length upto 1st line)
+        const cumulative_len = [0];
+        // Concatenation of all the lines rendered.
+        let concatenated_string = '';
+        lines.forEach((line, index) => {
+        cumulative_len.push(cumulative_len[index] + line.text.length);
+        concatenated_string += line.text;
+        });
+
+        /// array of JSX.Element
+        const _accViews = [];
+        /// We are assuming that link is always contained in the concatenated string
+        links.forEach((link, index) => {
+        const start = concatenated_string.indexOf(link.text);
+        const end = start + link.text.length - 1;
+        const sIdx = indexLte(cumulative_len, start);
+        const eIdx = indexLte(cumulative_len, end);
+        _accViews.push((
+            <Text key={"__Acc_View_rtb" + index} 
+                style={{height: lines[eIdx].y - lines[sIdx].y + lines[eIdx].height, width: lines[sIdx].width, position: 'absolute', top: 1+lines[sIdx].y, left: lines[sIdx].x}}
+                accessibilityLabel={link.text}
+                accessibilityRole='link'
+                accessible={true}
+                onPress={() => {link.onClick()}}>{' '}</Text>));
+
+        });
+        setAccContainers(_accViews);
+    }
+    // NOTE - If any padding/margin is applied to the root Text component, same should be applied to the styles of accessibility containers.
+    return (
+        <>
+            <Text key={"paragraph" + props.index} numberOfLines={props.numberOfLines}
+                onTextLayout={(event) => {
+                    if (!accContainers) {
+                        const lines = event.nativeEvent.lines;
+                        _linksSetPromise.current.then(() => {
+                            addAccContainers(lines, _links.current);
+                        });
+                    }
+                }}
+            >
+                {props.thisArg.getTextRunElements(props.paragraph, setLinks)}
+            </Text >
+            {accContainers}
+        </>
+    )
+
+}
+
+/// Finds index of the greatest number <= key in an array sorted in increasing order.
+function indexLte(array, key) {
+    let low = 0;
+    let high = array.length - 1;
+    while (low < high) {
+        const m = Math.floor((low + high)/2);
+        if (key === array[m]) {
+            return m;
+        } else if (key < array[m]) {
+            high = m-1;
+        } else {
+            low = m+1;
+        }
+    }
+
+    if (array[low] > key) {
+        return Math.max(low - 1, 0)
+    };
+
+    return low;
+}

--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -132,6 +132,10 @@ export class RichTextBlock extends React.Component {
     }
 
     render() {
+        if (!this.payload.paragraphs) {
+            this.payload.paragraphs = [{"inlines": this.payload.inlines}];
+        }
+
         return (<InputContextConsumer>
             {({ onExecuteAction }) => {
                 this.onExecuteAction = onExecuteAction;

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -11,7 +11,8 @@ import {
 	TextInput,
 	Modal,
 	Button,
-	ViewPropTypes
+	ViewPropTypes,
+	Platform
 } from 'react-native';
 
 import { InputContextConsumer } from '../../utils/context';

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -84,10 +84,12 @@ export class PickerInput extends React.Component {
 					<ElementWrapper configManager={this.props.configManager} style={styles.elementWrapper} json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 						<TouchableOpacity style={styles.inputWrapper} onPress={this.props.showPicker}
+							accessibilityLabel={Platform.OS === 'android' ? (this.payload.altText || this.props.value || placeholder) : undefined}
 							accessibilityRole='button'>
 							{/* added extra view to fix touch event in ios . */}
 							<View
 								accessible={true}
+								importantForAccessibility={'no-hide-descendants'}
 								accessibilityLabel={this.payload.altText || this.props.value || placeholder}
 								pointerEvents='none'
 								style={this.getComputedStyles(showErrors)}>

--- a/source/community/reactnative/src/components/inputs/toggle-input.js
+++ b/source/community/reactnative/src/components/inputs/toggle-input.js
@@ -69,7 +69,7 @@ export class ToggleInput extends React.Component {
 						return (
 							<View
 								accessible={true}
-								accessibilityLabel={this.altText}
+								accessibilityLabel={this.altText || Platform.OS === 'android' ? this.title : undefined}
 								style={styles.toggleView}
 								accessibilityRole={'switch'}
 								onAccessibilityAction={
@@ -94,7 +94,7 @@ export class ToggleInput extends React.Component {
 										this.toggleValueChanged(toggleValue, addInputItem)
 									}}>
 								</Switch>
-								<View style={styles.titleContainer}>
+								<View style={styles.titleContainer} importantForAccessibility='no-hide-descendants'>
 									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title}/>
 								</View>
 							</View>

--- a/source/community/reactnative/src/visualizer/payloads/payloads/Accessibility.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/Accessibility.json
@@ -40,8 +40,35 @@
 					"type": "Action.Submit",
 					"title": "OK",
 					"data": "submit"
+				},
+				{
+					"type": "RichTextBlock",
+					"wrap": true,
+					"paragraphs": [
+					{
+						"inlines": [
+							{
+								"type": "TextRun",
+								"text": "Please click here: "
+							},
+							{
+								"type": "TextRun",
+								"text": "a very very long link that opens bing.com",
+								"selectAction": {
+									"type": "Action.OpenUrl",
+									"url": "bing.com"
+								}
+							},
+							{
+								"type": "TextRun",
+								"text": ". Gap. "
+							}
+							
+						]
+					}
+				]
 				}
-			]
+			]	
 		}
 	]
 }

--- a/source/community/reactnative/src/visualizer/payloads/payloads/Accessibility.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/Accessibility.json
@@ -67,6 +67,29 @@
 						]
 					}
 				]
+				},
+				{
+					"type": "RichTextBlock",
+					"wrap": true,
+					"paragraphs": [
+					{
+						"inlines": [
+							{
+								"type": "TextRun",
+								"text": "Please click here: "
+							},
+							{
+								"type": "TextRun",
+								"text": "bing.com",
+								"selectAction": {
+									"type": "Action.OpenUrl",
+									"url": "bing.com"
+								}
+							}
+							
+						]
+					}
+				]
 				}
 			]	
 		}


### PR DESCRIPTION
# Description

It is not possible to bring focus to hyperlinks created using rich-text-block. It is a blocking experience for the screen reader user.

This PR also fixes double focus on Date/Time pickers and Switch input in Android.

# Fix
(Have raised an issue with React native: https://github.com/facebook/react-native/issues/32004, this fix is until RN resolves it).

Rich text block uses nested <Text> components, which are internally concatenated onto a single <Text> - Spannable in Android and NSAttributableString in iOS. However, the information about links is left out from an accessibility point of view.

To fix this, we create empty, invisible text components and place them where the hyperlink is supposed to be. We only have information about the position of each line and what text it contains, and not the position of the individual text. So, we create containers on lines that contain the hyperlink text. A similar approach is used in WhatsApp (known for good accessibility practices).

The focus order goes like this:
1. Complete text block
2. First link (if any)
3. Second link (if any)
4. ...

This is not the best fix if the same line contains two different links, but I think that will be a very small fraction of use cases and anyways it seems like the best we can do.

# Validation
Can we be verified using the accessibility.json payload.

Have verified on an Adaptive card with hyperlinks (rich text block).

Screenshots (showing focus order on single line and multi-line spanning links)
![IMG_0657](https://user-images.githubusercontent.com/25797471/131243513-a5758415-d371-41d8-b95c-b320abcab06f.jpg)
![IMG_0658](https://user-images.githubusercontent.com/25797471/131243518-a6033132-114f-41b9-af51-193758cf1bc8.jpg)
