### PR TITLE
Validated Font colour detection in cards

### DIFF
--- a/source/pic2card/mystique/extract_properties.py
+++ b/source/pic2card/mystique/extract_properties.py
@@ -202,16 +202,6 @@ class FontColor(AbstractFontColor):  # pylint: disable=too-few-public-methods
         if found_colors:
             index = distances.index(min(distances))
             color = found_colors[index]
-            if found_colors[index] == "Light":
-                background = q_a.getpalette()[:3]
-                foreground = q_a.getpalette()[3:6]
-                distance = np.sqrt(
-                    np.sum(
-                        (np.asarray(background) - np.asarray(foreground)) ** 2
-                    )
-                )
-                if distance < 150:
-                    color = "Default"
         return color
 
 


### PR DESCRIPTION
- Validated the font colour detection for cards with background colour
- Since we are working with the synthetic data set, it will have cards with background colour and validated the font colour detection.
- In Adaptive cards site, light colour font was getting detected as light greying colour but in dev UI it was detected as light colour. To avoid font colour  getting merged with the background, it was set to default colour. That logic was removed since light colour font was converted as light greying colour in adaptive cards site.
![Screenshot from 2021-10-18 02-38-52](https://user-images.githubusercontent.com/46240940/137645243-688e7863-d4fc-4137-997e-ad75fda2f46b.png)
![Screenshot from 2021-10-18 02-43-10](https://user-images.githubusercontent.com/46240940/137645245-a5dfea6f-79ef-4f02-a1bd-45b24706752e.png)


