### PR TITLE
Input-Label themeconfig, default Checkbox/RadioButton spacing

### DIFF
--- a/source/community/reactnative/src/components/inputs/choice-set/check-box.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/check-box.js
@@ -19,6 +19,7 @@ const IMAGE_COLOR_PROPERTY = "tintColor";
 const TEXT_COLOR_PROPERTY = "color";
 const styles = StyleSheet.create({
 	contentStyle: {
+		marginVertical: 3,
 		alignItems: Constants.CenterString
 	},
 	labelStyle: {

--- a/source/community/reactnative/src/components/inputs/input-label.js
+++ b/source/community/reactnative/src/components/inputs/input-label.js
@@ -20,17 +20,25 @@ export default class InputLabel extends React.Component {
 		this.isRequired = props.isRequired || false;
 		this.hostConfig = props.configManager.hostConfig;
 		this.altText = props.altText;
+		this.applyStyleConfig = props.applyStyleConfig;
 	}
 
 	render() {
-		const { label, wrap, style } = this;
+		const { label, wrap, style, applyStyleConfig } = this;
+
+		// NOTE :: Do not apply label styles on Toggle, other Input's labels style is picked from themeconfig
+		let computedStyle = style;
+		if (typeof applyStyleConfig !== 'boolean' || applyStyleConfig) {
+			computedStyle = this.props.configManager.styleConfig.inputLabel;
+		}
+
 		let inputLabel = null;
 		if (label != Constants.EmptyString) {
 			if (typeof label == Constants.TypeString) {
 				inputLabel = (
 					<Label
 						text={label}
-						style={[this.props.configManager.styleConfig.defaultFontConfig, style]}
+						style={[this.props.configManager.styleConfig.defaultFontConfig, computedStyle]}
 						configManager={this.props.configManager}
 						wrap={wrap}
 						altText={this.props.altText} />

--- a/source/community/reactnative/src/components/inputs/toggle-input.js
+++ b/source/community/reactnative/src/components/inputs/toggle-input.js
@@ -95,7 +95,7 @@ export class ToggleInput extends React.Component {
 									}}>
 								</Switch>
 								<View style={styles.titleContainer} importantForAccessibility='no-hide-descendants'>
-									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title}/>
+									<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} wrap={this.wrapText} style={styles.title} label={this.title} applyStyleConfig={false}/>
 								</View>
 							</View>
 						)

--- a/source/community/reactnative/src/styles/style-config.js
+++ b/source/community/reactnative/src/styles/style-config.js
@@ -49,6 +49,9 @@ export class StyleConfig {
 			input: {
 				...this.themeConfig.input[Platform.OS]
 			},
+			inputLabel: {
+				...this.themeConfig.inputLabel[Platform.OS]
+			},
 			defaultPositiveButtonBackgroundColor: {
 				backgroundColor: this.hostConfig.containerStyles.default.foregroundColors.accent.default,
 			},

--- a/source/community/reactnative/src/utils/constants.js
+++ b/source/community/reactnative/src/utils/constants.js
@@ -48,6 +48,7 @@ export const WhiteColor = 'white';
 export const BlackColor = '#000000';
 export const LightBlack = "#404040";
 export const Grey300 = '#ACACAC';
+export const Grey900 = '#333333';
 export const buttonDefaultColor = "#1D9BF6";
 export const BackgroundDisabledColor = "rgba(0,0,0,.3)";
 

--- a/source/community/reactnative/src/utils/enums.js
+++ b/source/community/reactnative/src/utils/enums.js
@@ -177,6 +177,7 @@ export const ElementType = Object.freeze({
 
 export const ThemeElement = Object.freeze({
 	Input: "input",
+	InputLabel: "inputLabel",
 	Button: "button",
 	InputDate: "inputDate",
 	InputTime: "inputTime",

--- a/source/community/reactnative/src/utils/theme-config.js
+++ b/source/community/reactnative/src/utils/theme-config.js
@@ -6,6 +6,7 @@ export class ThemeConfig {
     constructor(obj = {}) {
         this.button = new Config(ThemeElement.Button, obj);
         this.input = new Config(ThemeElement.Input, obj);
+        this.inputLabel = new Config(ThemeElement.InputLabel, obj);
         this.inputDate = new Config(ThemeElement.InputDate, obj);
         this.inputTime = new Config(ThemeElement.InputTime, obj);
         this.radioButton = new Config(ThemeElement.RadioButton, obj);
@@ -71,6 +72,11 @@ export const defaultThemeConfig = {
         backgroundColor: Constants.WhiteColor,
         borderRadius: 5,
         borderWidth: 1
+    },
+    inputLabel: {
+        fontSize: 14,
+        fontWeight: '400',
+        color: Constants.Grey900
     },
     inputDate: {
         width: Constants.FullWidth,

--- a/source/community/reactnative/src/visualizer/payloads/scenarios/field-validation.json
+++ b/source/community/reactnative/src/visualizer/payloads/scenarios/field-validation.json
@@ -75,7 +75,16 @@
         {
           "type": "Container",
           "items": [
-              {
+            {
+                "type": "Input.Text",
+                "placeholder": "Default Value Input.Text",
+                "id": "defaultTextInput",
+                "isRequired": true,
+                "errorMessage": "Required text input with default value",
+                "label": "Text Field with Default Value",
+                "value": "This is default value"
+            },
+            {
                   "type": "Input.Text",
                   "placeholder": "Required text input",
                   "id": "requiredInput",

--- a/source/community/reactnative/src/visualizer/renderer.js
+++ b/source/community/reactnative/src/visualizer/renderer.js
@@ -67,6 +67,11 @@ export default class Renderer extends React.Component {
         input: {
             placeholderTextColor: Grey300
         },
+        inputLabel: {
+            fontSize: 13,
+            lineHeight: 18,
+            color: '#6E6E6E'
+        },
         inputDate: {
             placeholderTextColor: Grey300
         },


### PR DESCRIPTION
# Description

This PR adds support for Input-Label theming and styling via theme-config.
Also, adds default vertical spacing of 3 for Checkbox/RadioButton. Earlier the rows were too close, and was prone to unwanted taps.

# How Verified

Verified via input-form json template. Screenshots below.

| iOS Old | iOS New | Android Old | Android New |
| ----------- | ----------- | ----------- | ----------- |
| <img src="https://user-images.githubusercontent.com/72800429/139041965-ea576221-358e-430b-9981-f550cdf96fe7.png" width="150" height="300" /> | <img src="https://user-images.githubusercontent.com/72800429/139042433-6fcad86d-0881-40e8-90f6-26fc2255e389.png" width="150" height="300" /> | <img src="https://user-images.githubusercontent.com/72800429/139042549-83d43047-392c-4a6c-9cae-35da78a7d478.png" width="150" height="300" /> | <img src="https://user-images.githubusercontent.com/72800429/139042768-78001d0c-8169-4c55-a2de-d6a5538210f1.png" width="150" height="300" /> |
