### PR TITLE
Support for text line height and input border color(focus state)

### DIFF
--- a/source/community/reactnative/src/components/elements/label.js
+++ b/source/community/reactnative/src/components/elements/label.js
@@ -97,12 +97,20 @@ export class Label extends React.Component {
 			Enums.HorizontalAlignment.Left
 		));
 
+		// line-height
+		const lineHeight = this.hostConfig.getTextLineHeight(Utils.parseHostConfigEnum(
+			Enums.TextSize,
+			size,
+			Enums.TextSize.Default
+		));
+
 		return {
 			fontSize,
 			fontWeight: fontWeight.toString(),
 			fontFamily: fontFamilyValue,
 			color: colorValue,
-			textAlign
+			textAlign,
+			lineHeight
 		}
 	}
 }

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -44,6 +44,7 @@ export class Input extends React.Component {
 
 		this.inlineAction = {};
 		this.state = {
+			isFocused: false,
 			showInlineActionErrors: false,
 			text: Constants.EmptyString,
 		}
@@ -94,8 +95,8 @@ export class Input extends React.Component {
 									clearButtonMode={Constants.WhileEditingString}
 									textContentType={this.textStyle}
 									keyboardType={this.keyboardType}
-									onFocus={this.props.handleFocus}
-									onBlur={this.props.handleBlur}
+									onFocus={this.handleFocus}
+									onBlur={this.handleBlur}
 									value={this.props.value}
 									onChangeText={(text) => this.props.textValueChanged(text, addInputItem)}
 								/>
@@ -118,8 +119,9 @@ export class Input extends React.Component {
 		const { isMultiline } = this;
 
 		// remove placeholderTextColor from styles object before using
-		const { placeholderTextColor, ...stylesObject } = this.styleConfig.input;
+		const { placeholderTextColor, activeColor, inactiveColor, ...stylesObject } = this.styleConfig.input;
 		let inputComputedStyles = [stylesObject, styles.input];
+		inputComputedStyles.push({ borderColor: this.state.isFocused ? activeColor : inactiveColor })
 		isMultiline ?
 			inputComputedStyles.push(styles.multiLineHeight) :
 			inputComputedStyles.push(styles.singleLineHeight);
@@ -269,9 +271,17 @@ export class Input extends React.Component {
 
 	handleFocus = () => {
 		this.setState({
+			isFocused: true,
 			showInlineActionErrors: false
 		});
 		this.props.handleFocus();
+	}
+
+	handleBlur = () => {
+		this.setState({
+			isFocused: false
+		});
+		this.props.handleBlur();
 	}
 
 	/**

--- a/source/community/reactnative/src/utils/host-config.js
+++ b/source/community/reactnative/src/utils/host-config.js
@@ -395,7 +395,13 @@ class FontConfig {
 export class HostConfig {
 	choiceSetInputValueSeparator = ",";
 	supportsInteractivity = true;
-	lineHeights;
+	lineHeights = {
+		small: 17,
+		default: 20,
+		medium: 23,
+		large: 26,
+		extraLarge: 34
+	};
 	spacing = {
 		none: 0,
 		small: 3,
@@ -584,6 +590,26 @@ export class HostConfig {
 				return fontStyle.fontSizes.extraLarge;
 			default:
 				return fontStyle.fontSizes.default;
+		}
+	}
+
+	/**
+	 * @param {string} fontSize 
+	 */
+	 getTextLineHeight = (fontSize) => {
+		switch (fontSize) {
+			case Enums.TextSize.Small:
+				return this.lineHeights.small
+			case Enums.TextSize.Default:
+				return this.lineHeights.default;
+			case Enums.TextSize.Medium:
+				return this.lineHeights.medium;
+			case Enums.TextSize.Large:
+				return this.lineHeights.large;
+			case Enums.TextSize.ExtraLarge:
+				return this.lineHeights.extraLarge;
+			default:
+				return this.lineHeights.default;
 		}
 	}
 

--- a/source/community/reactnative/src/utils/theme-config.js
+++ b/source/community/reactnative/src/utils/theme-config.js
@@ -68,7 +68,9 @@ export const defaultThemeConfig = {
         },
     },
     input: {
-        borderColor: Constants.EmphasisColor,
+		activeColor: Constants.BlackColor,
+		inactiveColor: Constants.LightBlack,
+		borderColor: Constants.EmphasisColor,
         backgroundColor: Constants.WhiteColor,
         borderRadius: 5,
         borderWidth: 1


### PR DESCRIPTION
# Description
This PR:
- Adds support for line height for text block component.
- Adds functionality to configure border color for input component when in focus.

# How Verified

Line Height | Before | After
-- | -- | --
iOS | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-11-12 at 13 03 13](https://user-images.githubusercontent.com/25148603/141438042-7c766fce-8148-482a-90d6-410f490aa885.png) |  ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-11-12 at 13 12 04](https://user-images.githubusercontent.com/25148603/141438301-247245bb-b4d7-4407-adf8-5030e285281d.png)
Android |  ![Screenshot_1636709771](https://user-images.githubusercontent.com/25148603/141445125-e56dec03-a00c-43ce-8345-c17d96445670.png) |  ![Screenshot_1636705962](https://user-images.githubusercontent.com/25148603/141439678-9c1a2f3a-543d-4588-b3ed-d84e429428fc.png)


Input Border | Before | After
-- | -- | --
iOS |  ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-11-12 at 13 03 26](https://user-images.githubusercontent.com/25148603/141439243-be50986e-040c-4b30-899a-f0db18e2ed77.png) |  ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-11-12 at 14 23 26](https://user-images.githubusercontent.com/25148603/141439301-748e2771-ecb9-4cd1-bdf0-f1772895bdad.png)
Android | ![Screenshot_1636709786](https://user-images.githubusercontent.com/25148603/141445215-907e9dbc-594f-401d-a66c-0d48d9aa48c1.png) |  ![Screenshot_1636707575](https://user-images.githubusercontent.com/25148603/141439945-1236515c-9bee-4a22-8b58-714044ee5085.png)
