### PR TITLE
Adding support - custom styles for input container

### DIFF
--- a/source/community/reactnative/src/components/actions/select-Action.js
+++ b/source/community/reactnative/src/components/actions/select-Action.js
@@ -66,7 +66,7 @@ export class SelectAction extends React.Component {
 					onPress={() => { this.onClickHandle() }}
 					disabled={this.payload.isEnabled === undefined ? false : !this.payload.isEnabled}
 					accessible={true}
-					accessibilityLabel={this.payload.altText}
+					accessibilityLabel={this.props.altText}
 					accessibilityRole={Constants.Button}
 					accessibilityState={{ disabled: this.payload.isEnabled === undefined ? false : !this.payload.isEnabled }}
 					style={this.props.style}>

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -121,12 +121,12 @@ export class Input extends React.Component {
 		const { isMultiline } = this;
 
 		// remove placeholderTextColor from styles object before using
-		const { placeholderTextColor, activeColor, inactiveColor, ...stylesObject } = this.styleConfig.input;
+		const { placeholderTextColor, activeColor, inactiveColor, singleLineHeight, multiLineHeight, ...stylesObject } = this.styleConfig.input;
 		let inputComputedStyles = [stylesObject, styles.input];
 		inputComputedStyles.push({ borderColor: this.state.isFocused ? activeColor : inactiveColor })
 		isMultiline ?
-			inputComputedStyles.push(styles.multiLineHeight) :
-			inputComputedStyles.push(styles.singleLineHeight);
+			inputComputedStyles.push(multiLineHeight ? { height: multiLineHeight } : styles.multiLineHeight) :
+			inputComputedStyles.push(singleLineHeight ? { height: singleLineHeight } : styles.singleLineHeight);
 		this.props.isError && showErrors ?
 			inputComputedStyles.push(this.styleConfig.borderAttention) :
 			inputComputedStyles.push(this.styleConfig.inputBorderColor);

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -80,7 +80,7 @@ export class Input extends React.Component {
 						if (!inputArray[this.id])
 							addInputItem(this.id, { value: this.props.value, errorState: this.props.isError });
 						return (
-							<ElementWrapper configManager={this.props.configManager} style={styles.elementWrapper} json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
+							<ElementWrapper configManager={this.props.configManager} style={[styles.elementWrapper, this.styleConfig.inputContainer]} json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
 								<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 								<TextInput
 									style={this.getComputedStyles(showErrors)}
@@ -216,7 +216,7 @@ export class Input extends React.Component {
 			let opacityStyle = { opacity: inlineAction.isEnabled == undefined ? 1.0 : inlineAction.isEnabled ? 1.0 : 0.4 };
 			return (
 				<View>
-					<ElementWrapper configManager={this.props.configManager} json={payload} style={styles.elementWrapper} isError={this.props.isError} isFirst={this.props.isFirst}>
+					<ElementWrapper configManager={this.props.configManager} json={payload} style={[styles.elementWrapper, this.styleConfig.inputContainer]} isError={this.props.isError} isFirst={this.props.isFirst}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 						<View style={wrapperStyle} >
 							<TextInput
@@ -330,7 +330,7 @@ const styles = StyleSheet.create({
     },
     elementWrapper: {
         flex: 1,
-        marginVertical: 3
+        marginTop: 3
     },
     input: {
         width: Constants.FullWidth,

--- a/source/community/reactnative/src/styles/style-config.js
+++ b/source/community/reactnative/src/styles/style-config.js
@@ -99,6 +99,9 @@ export class StyleConfig {
 			},
 			actionSet: {
 				...this.themeConfig.actionSet[Platform.OS]
+			},
+			inputContainer: {
+				...this.themeConfig.inputContainer[Platform.OS]
 			}
 		};
 		return styles;

--- a/source/community/reactnative/src/utils/enums.js
+++ b/source/community/reactnative/src/utils/enums.js
@@ -192,5 +192,6 @@ export const ThemeElement = Object.freeze({
 	Switch: "switch",
 	InlineAction: "inlineAction",
 	InlineActionText: "inlineActionText",
-	ActionSet: "actionSet"
+	ActionSet: "actionSet",
+	InputContainer: "inputContainer"
 });

--- a/source/community/reactnative/src/utils/theme-config.js
+++ b/source/community/reactnative/src/utils/theme-config.js
@@ -21,6 +21,7 @@ export class ThemeConfig {
         this.inlineAction = new Config(ThemeElement.InlineAction, obj);
         this.inlineActionText = new Config(ThemeElement.InlineActionText, obj);
 		this.actionSet = new Config(ThemeElement.ActionSet, obj);
+		this.inputContainer = new Config(ThemeElement.InputContainer, obj);
     }
 }
 
@@ -184,5 +185,6 @@ export const defaultThemeConfig = {
     },
     inlineAction: {},
     inlineActionText: {},
-	actionSet: {}
+	actionSet: {},
+	inputContainer: {}
 }


### PR DESCRIPTION
# Description

There is extra bottom margin that is added to input element's wrapper, which when aligned to bottom vertical content alignment is leading to disparity between web and mobile. 

Fix:
1. Changed marginVertical to marginTop, to remove bottom margin
2. Added support for custom styling for inputContainer

# Sample Card

`{
    "type": "AdaptiveCard",
    "body": [
        {
            "type": "ColumnSet",
            "columns": [
                {
                    "type": "Column",
                    "width": "stretch",
                    "verticalContentAlignment": "Bottom",
                    "items": [
                        {
                            "type": "Input.Text",
                            "label": "Enter location details",
                            "placeholder": "Building name",
                            "id": "input1"
                        }
                    ]
                },
                {
                    "type": "Column",
                    "width": "stretch",
                    "verticalContentAlignment": "Bottom",
                    "items": [
                        {
                            "type": "ActionSet",
                            "actions": [
                                {
                                    "type": "Action.Submit",
                                    "title": "Search",
                                    "id": "button1"
                                }
                            ]
                        }
                    ]
                }
            ]
        }
    ],
    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
    "version": "1.3"
}
`

# How is the change verified

How you verified the fix, including one or all of the following:
1. Regression was tested with existing scenarios on Visualizer and on our end.
3. Scenarios were tested with randomly generated templates, one of them is attached in the description and changes were tested on both Android and iOS.

# Screenshots
## Before

## After
