### PR TITLE
Placeholder text color support for ChoiceSet(compact) style

### DIFF
--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -93,7 +93,7 @@ export class ChoiceSetInput extends React.Component {
 	 * @param {string} value 
 	 */
 	getPickerSelectedValue = (value, addInputItem) => {
-		if (Utils.isNullOrEmpty(value)){
+		if (Utils.isNullOrEmpty(value)) {
 			addInputItem(this.id, { value: value, errorState: this.state.isError });
 			return this.placeholder;
 		}
@@ -157,6 +157,19 @@ export class ChoiceSetInput extends React.Component {
 	}
 
 	/**
+	 * @description Get styles for placeholder/choice selected for picker component.
+	 * @returns {object} - Styles computed based on the payload
+	 */
+	getPickerComponentStyles = (addInputItem) => {
+		// remove placeholderColor from styles object before using
+		const { placeholderColor, ...stylesObject } = this.styleConfig.dropdownText;
+		let inputComputedStyles = [stylesObject];
+		placeholderColor && (this.getPickerSelectedValue(this.state.selectedPickerValue, addInputItem) === this.placeholder) && inputComputedStyles.push({ color: placeholderColor });
+
+		return inputComputedStyles;
+	}
+
+	/**
 	 * @description Renders Picker component as per the json for single choice compact style.
 	 * Renders custom element containing textbox with placeholder/default/selected value with dropdown image.
 	 * It hides the default picker element which shows its own text box in Android and shows custom picker element.
@@ -174,7 +187,7 @@ export class ChoiceSetInput extends React.Component {
 				>
 					<View style={this.styleConfig.dropdown}>
 						<Text
-							style={[this.styleConfig.dropdownText, this.styleConfig.defaultFontConfig]}
+							style={[this.getPickerComponentStyles(addInputItem), this.styleConfig.defaultFontConfig]}
 						>
 							{this.getPickerSelectedValue(this.state.selectedPickerValue,
 								addInputItem)
@@ -197,7 +210,7 @@ export class ChoiceSetInput extends React.Component {
 		let picker = (
 			<Picker
 				mode={'dropdown'}
-				style={(Platform.OS === Constants.PlatformAndroid) && {width:'100%',height:'100%',position:'absolute',opacity:0}}
+				style={(Platform.OS === Constants.PlatformAndroid) && { width: '100%', height: '100%', position: 'absolute', opacity: 0 }}
 				itemStyle={this.styleConfig.picker}
 				selectedValue={this.getPickerInitialValue(addInputItem)}
 				onValueChange={


### PR DESCRIPTION
## Description 

This PR adds support for placeholder text color for choice set (compact) style.

## How Verified

Platform | Before | After
-|-|-
iOS | <img alt="[Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-04 at 12 52 03]" src="https://user-images.githubusercontent.com/25148603/148028946-71f706be-02c8-460e-b61d-1fa3f8083930.png" width="200"/> | <img alt="[Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-04 at 12 51 30]" src="https://user-images.githubusercontent.com/25148603/148028422-d77272ed-f311-4992-8abb-99f021e58171.png" width="200"/> 
Android | <img alt="[Screenshot_1641282158]" src="https://user-images.githubusercontent.com/25148603/148029048-629e5c84-2280-42f2-96fb-e3f944e6bc9c.png" width="200"/>  | <img alt="[Screenshot_1641282700]" src="https://user-images.githubusercontent.com/25148603/148029432-148c8783-37f7-499f-b3f3-9de68ba1f8e6.png" width="200"/> 