### PR TITLE
Fixed selected value issue for Date/Time component

### DIFF
--- a/source/community/reactnative/src/components/containers/container.js
+++ b/source/community/reactnative/src/components/containers/container.js
@@ -84,8 +84,7 @@ export class Container extends React.Component {
 	getValidationText = () => {
 		const payload = this.payload;
 		const validationTextStyles = [this.styleConfig.fontFamilyName, this.styleConfig.defaultDestructiveButtonForegroundColor];
-		const errorMessage = (payload.validation && payload.validation.errorMessage) ?
-			payload.validation.errorMessage : Constants.ErrorMessage;
+		const errorMessage = (payload.validation && payload.validation.errorMessage);
 
 		return (
 			<Text style={validationTextStyles}>

--- a/source/community/reactnative/src/components/containers/container.js
+++ b/source/community/reactnative/src/components/containers/container.js
@@ -84,7 +84,8 @@ export class Container extends React.Component {
 	getValidationText = () => {
 		const payload = this.payload;
 		const validationTextStyles = [this.styleConfig.fontFamilyName, this.styleConfig.defaultDestructiveButtonForegroundColor];
-		const errorMessage = (payload.validation && payload.validation.errorMessage);
+		const errorMessage = (payload.validation && payload.validation.errorMessage) ?
+			payload.validation.errorMessage : ((this.payload.isRequired && Constants.ErrorMessage) || Constants.EmptyString);
 
 		return (
 			<Text style={validationTextStyles}>

--- a/source/community/reactnative/src/components/elements/element-wrapper.js
+++ b/source/community/reactnative/src/components/elements/element-wrapper.js
@@ -105,7 +105,7 @@ export default class ElementWrapper extends React.Component {
 		const validationTextStyles = [this.styleConfig.fontFamilyName, this.styleConfig.defaultDestructiveButtonForegroundColor];
 		return (
 			<Text style={validationTextStyles}>
-				{payload.errorMessage}
+				{payload.errorMessage || (payload.isRequired && Constants.ErrorMessage)}
 			</Text>
 		)
 	}

--- a/source/community/reactnative/src/components/elements/element-wrapper.js
+++ b/source/community/reactnative/src/components/elements/element-wrapper.js
@@ -105,7 +105,7 @@ export default class ElementWrapper extends React.Component {
 		const validationTextStyles = [this.styleConfig.fontFamilyName, this.styleConfig.defaultDestructiveButtonForegroundColor];
 		return (
 			<Text style={validationTextStyles}>
-				{payload.errorMessage || (payload.isRequired && Constants.ErrorMessage)}
+				{payload.errorMessage || (payload.isRequired && !this.props.value && Constants.ErrorMessage)}
 			</Text>
 		)
 	}

--- a/source/community/reactnative/src/components/elements/element-wrapper.js
+++ b/source/community/reactnative/src/components/elements/element-wrapper.js
@@ -105,7 +105,7 @@ export default class ElementWrapper extends React.Component {
 		const validationTextStyles = [this.styleConfig.fontFamilyName, this.styleConfig.defaultDestructiveButtonForegroundColor];
 		return (
 			<Text style={validationTextStyles}>
-				{payload.errorMessage || Constants.ErrorMessage}
+				{payload.errorMessage}
 			</Text>
 		)
 	}

--- a/source/community/reactnative/src/components/inputs/date-input.js
+++ b/source/community/reactnative/src/components/inputs/date-input.js
@@ -1,6 +1,10 @@
 /**
  * Date component based on the given payload.
  * 
+ * For range is present in given payload,
+ * If no default value is given: it selects max value from payload else, current date in date picker.
+ * If given default value is not within the range: it selects minimum or maximum value from payload depending on the given default value in date picker.
+ * 
  * Refer https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/card-schema#inputdate
  */
 

--- a/source/community/reactnative/src/components/inputs/date-input.js
+++ b/source/community/reactnative/src/components/inputs/date-input.js
@@ -64,6 +64,7 @@ export class DateInput extends React.Component {
 	 * @description Hides the DatePicker on close event
 	 */
 	handleModalClose = () => {
+		!this.state.value && this.setDate(this.state.chosenDate);
 		this.setState({ modalVisible: false })
 	}
 

--- a/source/community/reactnative/src/components/inputs/date-input.js
+++ b/source/community/reactnative/src/components/inputs/date-input.js
@@ -16,6 +16,8 @@ export class DateInput extends React.Component {
 		super(props);
 
 		this.payload = props.json;
+		this.minDate = this.payload.min ? this.parseDateString(this.payload.min) : undefined;
+		this.maxDate = this.payload.max ? this.parseDateString(this.payload.max) : undefined;
 		this.parseHostConfig();
 	}
 
@@ -24,15 +26,26 @@ export class DateInput extends React.Component {
 	 */
 	parseHostConfig() {
 		this.state = {
-			chosenDate: this.payload.value ? this.parseDateString(this.payload.value) : new Date(),
-			minDate: this.payload.min ? this.parseDateString(this.payload.min) : undefined,
-			maxDate: this.payload.max ? this.parseDateString(this.payload.max) : undefined,
+			chosenDate: this.getChosenDate(),
 			modalVisible: false,
 			modalVisibleAndroid: false,
 			value: this.payload.value ? this.payload.value : Constants.EmptyString
 		}
 
 		this.state.setDate = this.setDate.bind(this);
+	}
+
+	/**
+	 * @description Return chosen date value based on value and range present in payload.
+	 */
+	getChosenDate() {
+		dateValue = this.payload.value && this.parseDateString(this.payload.value);
+		if (dateValue) {
+			if (this.minDate && dateValue < this.minDate) return this.minDate;
+			if (this.maxDate && dateValue > this.maxDate) return this.maxDate;
+			return dateValue;
+		}
+		return this.maxDate || new Date();
 	}
 
 	/**
@@ -64,7 +77,7 @@ export class DateInput extends React.Component {
 	 * @description Hides the DatePicker on close event
 	 */
 	handleModalClose = () => {
-		!this.state.value && this.setDate(this.state.chosenDate);
+		this.setDate(this.state.chosenDate);
 		this.setState({ modalVisible: false })
 	}
 
@@ -111,8 +124,8 @@ export class DateInput extends React.Component {
 					modalVisible={this.state.modalVisible}
 					handleModalClose={this.handleModalClose}
 					chosenDate={this.state.chosenDate || new Date()}
-					minDate={this.state.minDate}
-					maxDate={this.state.maxDate}
+					minDate={this.minDate}
+					maxDate={this.maxDate}
 					handleDateChange={this.handleDateChange}
 					mode='date'
 					configManager={this.props.configManager}
@@ -122,8 +135,8 @@ export class DateInput extends React.Component {
 					<DateTimePicker
 						mode="date"
 						value={this.state.chosenDate}
-						minimumDate={this.state.minDate}
-						maximumDate={this.state.maxDate}
+						minimumDate={this.minDate}
+						maximumDate={this.maxDate}
 						onChange={(event, date) => this.setDate(date)}
 					/>
 				}

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -41,7 +41,7 @@ export class Input extends React.Component {
 		this.textStyle = Constants.EmptyString;
 		this.label = Constants.EmptyString;
 		this.isRequired = this.payload.isRequired || false;
-		this.errorMessage = this.payload.errorMessage || (this.payload.isRequired && Constants.ErrorMessage);
+		this.errorMessage = this.payload.errorMessage;
 
 		this.inlineAction = {};
 		this.state = {
@@ -80,7 +80,7 @@ export class Input extends React.Component {
 						if (!inputArray[this.id])
 							addInputItem(this.id, { value: this.props.value, errorState: this.props.isError });
 						return (
-							<ElementWrapper configManager={this.props.configManager} style={[styles.elementWrapper, this.styleConfig.inputContainer]} json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst}>
+							<ElementWrapper configManager={this.props.configManager} style={[styles.elementWrapper, this.styleConfig.inputContainer]} json={this.payload} isError={this.props.isError} isFirst={this.props.isFirst} value={this.props.value}>
 								<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 								<TextInput
 									style={this.getComputedStyles(showErrors)}
@@ -216,7 +216,7 @@ export class Input extends React.Component {
 			let opacityStyle = { opacity: inlineAction.isEnabled == undefined ? 1.0 : inlineAction.isEnabled ? 1.0 : 0.4 };
 			return (
 				<View>
-					<ElementWrapper configManager={this.props.configManager} json={payload} style={[styles.elementWrapper, this.styleConfig.inputContainer]} isError={this.props.isError} isFirst={this.props.isFirst}>
+					<ElementWrapper configManager={this.props.configManager} json={payload} style={[styles.elementWrapper, this.styleConfig.inputContainer]} isError={this.props.isError} isFirst={this.props.isFirst} value={this.props.value}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.isRequired} label={label} />
 						<View style={wrapperStyle} >
 							<TextInput

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -41,7 +41,7 @@ export class Input extends React.Component {
 		this.textStyle = Constants.EmptyString;
 		this.label = Constants.EmptyString;
 		this.isRequired = this.payload.isRequired || false;
-		this.errorMessage = this.payload.errorMessage;
+		this.errorMessage = this.payload.errorMessage || (this.payload.isRequired && Constants.ErrorMessage);
 
 		this.inlineAction = {};
 		this.state = {

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -41,7 +41,7 @@ export class Input extends React.Component {
 		this.textStyle = Constants.EmptyString;
 		this.label = Constants.EmptyString;
 		this.isRequired = this.payload.isRequired || false;
-		this.errorMessage = this.payload.errorMessage || Constants.ErrorMessage;
+		this.errorMessage = this.payload.errorMessage;
 
 		this.inlineAction = {};
 		this.state = {

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -37,7 +37,7 @@ export class PickerInput extends React.Component {
 		this.label = Constants.EmptyString;
 		this.parseHostConfig();
 
-		this.errorMessage = this.payload.errorMessage || (this.payload.isRequired && Constants.ErrorMessage);
+		this.errorMessage = this.payload.errorMessage;
 
 		this.state = {
 			isRequired: this.payload.isRequired || false,
@@ -88,7 +88,7 @@ export class PickerInput extends React.Component {
 		return (
 			<InputContextConsumer>
 				{({ addInputItem, showErrors }) => (
-					<ElementWrapper configManager={this.props.configManager} style={styles.elementWrapper} json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst}>
+					<ElementWrapper configManager={this.props.configManager} style={styles.elementWrapper} json={this.payload} isError={this.state.isError} isFirst={this.props.isFirst} value={this.props.value}>
 						<InputLabel configManager={this.props.configManager} isRequired={this.state.isRequired} label={label} />
 						<TouchableOpacity style={styles.inputWrapper} onPress={this.props.showPicker}
 							accessibilityLabel={Platform.OS === 'android' ? (this.payload.altText || this.props.value || placeholder) : undefined}

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -37,7 +37,7 @@ export class PickerInput extends React.Component {
 		this.label = Constants.EmptyString;
 		this.parseHostConfig();
 
-		this.errorMessage = this.payload.errorMessage;
+		this.errorMessage = this.payload.errorMessage || (this.payload.isRequired && Constants.ErrorMessage);
 
 		this.state = {
 			isRequired: this.payload.isRequired || false,

--- a/source/community/reactnative/src/components/inputs/picker-input.js
+++ b/source/community/reactnative/src/components/inputs/picker-input.js
@@ -37,7 +37,7 @@ export class PickerInput extends React.Component {
 		this.label = Constants.EmptyString;
 		this.parseHostConfig();
 
-		this.errorMessage = this.payload.errorMessage || Constants.ErrorMessage;
+		this.errorMessage = this.payload.errorMessage;
 
 		this.state = {
 			isRequired: this.payload.isRequired || false,

--- a/source/community/reactnative/src/components/inputs/time-input.js
+++ b/source/community/reactnative/src/components/inputs/time-input.js
@@ -1,6 +1,10 @@
 /**
  * Date component based on the given payload.
  * 
+ * For range is present in given payload,
+ * If no default value is given: it selects max value from payload else, current time in time picker.
+ * If given default value is not within the range: it selects minimum or maximum value from payload depending on the given default value in time picker.
+ * 
  * Refer https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/card-schema#inputtime
  */
 

--- a/source/community/reactnative/src/components/inputs/time-input.js
+++ b/source/community/reactnative/src/components/inputs/time-input.js
@@ -79,6 +79,7 @@ export class TimeInput extends React.Component {
 	 * @description Hides the TimePicker on close event
 	 */
 	handleModalClose = () => {
+		!this.state.value && this.setTime(this.state.chosenTime);
 		this.setState({ modalVisible: false })
 	}
 

--- a/source/community/reactnative/src/components/inputs/time-input.js
+++ b/source/community/reactnative/src/components/inputs/time-input.js
@@ -16,6 +16,8 @@ export class TimeInput extends React.Component {
 		super(props);
 
 		this.payload = props.json;
+		this.minTime = this.payload.min ? this.parseTimeString(this.payload.min) : undefined;
+		this.maxTime = this.payload.max ? this.parseTimeString(this.payload.max) : undefined;
 		this.parseHostConfig();
 	}
 
@@ -24,9 +26,7 @@ export class TimeInput extends React.Component {
 	 */
 	parseHostConfig() {
 		this.state = {
-			chosenTime: this.payload.value ? this.parseTimeString(this.payload.value) : new Date(),
-			minTime: this.payload.min ? this.parseTimeString(this.payload.min) : undefined,
-			maxTime: this.payload.max ? this.parseTimeString(this.payload.max) : undefined,
+			chosenTime: this.getChosenTime(),
 			modalVisible: false,
 			modalVisibleAndroid: false,
 			value: this.payload.value ? this.payload.value : Constants.EmptyString
@@ -34,6 +34,20 @@ export class TimeInput extends React.Component {
 
 		this.state.setTime = this.setTime.bind(this);
 	}
+
+	/**
+	 * @description Return chosen time value based on value and range present in payload.
+	 */
+	getChosenTime() {
+		timeValue = this.payload.value && this.parseTimeString(this.payload.value);
+		if (timeValue) {
+			if (this.minTime && timeValue < this.minTime) return this.minTime;
+			if (this.maxTime && timeValue > this.maxTime) return this.maxTime;
+			return timeValue;
+		}
+		return this.maxTime || new Date();
+	}
+
 
 	/**
 	 * @description Return Date object from string.
@@ -79,7 +93,7 @@ export class TimeInput extends React.Component {
 	 * @description Hides the TimePicker on close event
 	 */
 	handleModalClose = () => {
-		!this.state.value && this.setTime(this.state.chosenTime);
+		this.setTime(this.state.chosenTime);
 		this.setState({ modalVisible: false })
 	}
 
@@ -116,8 +130,8 @@ export class TimeInput extends React.Component {
 					modalVisible={this.state.modalVisible}
 					handleModalClose={this.handleModalClose}
 					chosenDate={this.state.chosenTime || new Date()}
-					minDate={this.state.minTime}
-					maxDate={this.state.maxTime}
+					minDate={this.minTime}
+					maxDate={this.maxTime}
 					handleDateChange={this.handleTimeChange}
 					mode='time'
 					configManager={this.props.configManager}


### PR DESCRIPTION
### Description

This PR:
- [iOS] Fixes selected value issue for date/time component based on given default value and range given in the payload. For range date/time case:
i. If no default value is given, it selects maximum value from payload or current date/time. 
ii. If given default value is not within the range, it selects minimum or maximum value from payload depending on the given default value.

- [Both] Default error message ("Required") will now be displayed only in case of empty required field. As earlier, it displayed wrong message in case of other error scenarios also when no error message was present in payload.

### How Verified

- **Input - Error Message**

Platform | Before(Out of range) | After(Out of range) | Before(Empty required field) | After(Empty required field)
| - | - | - | - | -
iOS | <img alt="[ErrorBefore1]" src="https://user-images.githubusercontent.com/25148603/150776449-1b616177-a090-4020-ac9a-ac563f1b332a.png" width="180"/>  | <img alt="[ErrorAfter1]" src="https://user-images.githubusercontent.com/25148603/150776464-14ff1038-67c8-4363-894e-15bf5a51f6ba.png" width="180"/> | <img alt="[ErrorBefore2]" src="https://user-images.githubusercontent.com/25148603/150776476-05069245-bbf4-492b-8e56-be8c96385f2d.png" width="180"/> | <img alt="[ErrorAfter2]" src="https://user-images.githubusercontent.com/25148603/150776492-5f5f3af9-8d3b-46f1-80ed-b3bf91a65b93.png" width="180"/>
Android |  <img alt="[ErrorBefore3]" src="https://user-images.githubusercontent.com/25148603/150776775-12945a82-db8d-4fb2-8351-e589824f68a1.png" width="180"/> |  <img alt="[ErrorAfter3]" src="https://user-images.githubusercontent.com/25148603/150776787-97654a81-e7ce-48ef-972c-2fe7edee9ea8.png" width="180"/> |  <img alt="[ErrorBefore4]" src="https://user-images.githubusercontent.com/25148603/150776818-e4e501d9-4ee8-4267-843f-90615f11e464.png" width="180"/> |  <img alt="[ErrorAfter4]" src="https://user-images.githubusercontent.com/25148603/150776798-d66d1cf3-d636-4e3b-b573-91a4a8054a9f.png" width="180"/>

- **Date/Time** 

https://user-images.githubusercontent.com/25148603/149968000-36c9b7d3-61ec-4249-a78f-6435cdae013d.mov

https://user-images.githubusercontent.com/25148603/149968259-3faad0f3-0e1b-4ed0-97ec-4532edec3095.mov

For range as  {"min": "2017-09-20", "max": "2017-09-22"}

https://user-images.githubusercontent.com/25148603/150326254-6bbf4249-e196-46e9-a1e9-003ca7fc3ec2.mov

https://user-images.githubusercontent.com/25148603/150326347-06a1fd08-ce81-4c09-bbc0-68e45abfc727.mov
