### PR TITLE
FlexShrink if all the Column width are set to Auto

### DIFF
--- a/source/community/reactnative/src/components/containers/column.js
+++ b/source/community/reactnative/src/components/containers/column.js
@@ -113,7 +113,7 @@ export class Column extends React.Component {
 		}
 		else if (!this.column || this.column.width === 'auto') {
 			if (sizeValues.length == 0) {
-				containerViewStyle.push({ flexWrap: 'wrap' })
+				containerViewStyle.push({ flexShrink: 1 })
 			} else {
 				flex = minValue / maxValue
 			}
@@ -174,7 +174,7 @@ export class Column extends React.Component {
 		const minHeight = Utils.convertStringToNumber(this.column.minHeight);
 		//We will pass the style as array, since it can be updated in the container wrapper if required.
 		typeof minHeight === "number" && containerViewStyle.push({ minHeight });
-
+		// console.log(containerViewStyle, this.props.containerStyle);
 		return <ContainerWrapper configManager={this.props.configManager} json={this.column} hasBackgroundImage={this.props.hasBackgroundImage} isFirst={isFirst} isLast={isLast} style={[containerViewStyle]} containerStyle={this.props.containerStyle}>
 			<ActionComponent {...actionComponentProps}>
 				{separator && this.renderSeparator()}

--- a/source/community/reactnative/src/components/containers/column.js
+++ b/source/community/reactnative/src/components/containers/column.js
@@ -174,7 +174,6 @@ export class Column extends React.Component {
 		const minHeight = Utils.convertStringToNumber(this.column.minHeight);
 		//We will pass the style as array, since it can be updated in the container wrapper if required.
 		typeof minHeight === "number" && containerViewStyle.push({ minHeight });
-		// console.log(containerViewStyle, this.props.containerStyle);
 		return <ContainerWrapper configManager={this.props.configManager} json={this.column} hasBackgroundImage={this.props.hasBackgroundImage} isFirst={isFirst} isLast={isLast} style={[containerViewStyle]} containerStyle={this.props.containerStyle}>
 			<ActionComponent {...actionComponentProps}>
 				{separator && this.renderSeparator()}

--- a/source/community/reactnative/src/visualizer/payloads/payloads/ColumnSet.OverFlow.Width.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/ColumnSet.OverFlow.Width.json
@@ -1,0 +1,83 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "First Column First Column First Column First Column First Column First Column First Column First Column First Column First Column First Column ",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Second Column ",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Third Column",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ]
+        },        
+        {
+            "type": "ColumnSet",
+            "columns": [
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "First Column",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Second Column Second Column Second Column Second Column Second Column Second Column Second Column Second Column Second Column Second Column ",
+                            "wrap": true
+                        }
+                    ]
+                },
+                {
+                    "type": "Column",
+                    "width": "auto",
+                    "items": [
+                        {
+                            "type": "TextBlock",
+                            "text": "Third Column",
+                            "wrap": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.3"
+}

--- a/source/community/reactnative/src/visualizer/payloads/payloads/index.js
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/index.js
@@ -176,6 +176,10 @@ export default payloads = [
     "json": require('./ColumnSet_Container.VerticalStretch.json')
   },
   {
+    title: "ColumnSet.OverFlow.Width.json",
+    json: require('./ColumnSet.OverFlow.Width.json')
+  },
+  {
     "title": "Custom.Actions.Rendering.json",
     "json": require('./CustomActions.Rendering.json')
   },


### PR DESCRIPTION
# Related Issue

Long text overlaps the other columns in multi-column layout

# Description

When widths of all the columns in columnset are set to 'auto' and the textblock in one or more of the columns is very long, it doesn't wrap and overlaps with the next column or push the next column out of the screen.

The column container should be set with a flexShrink value of 1. So that the container shrinks the children along the main axis in the case in which the total size of the children overflows the size of the container on the main axis.

# Sample Card

Fixed card

![simulator_screenshot_E55ACAA3-B525-4949-B0E1-E61FAC7BCD42](https://user-images.githubusercontent.com/5258886/150668875-c3d7c7a9-593a-4d33-b0f6-917965a64f52.png)

# How Verified

1. Added the Payload with overflowing text in the payloads list.
2. Verified if the renderer renders it properly.
3. Compared the result with the web renderer.
