### PR TITLE
[Android] Fixed accessibility for Choice Set(compact) style

### DIFF
--- a/source/community/reactnative/package.json
+++ b/source/community/reactnative/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "^3.0.9",
-    "@react-native-picker/picker": "^1.9.11",
+    "@react-native-picker/picker": "^1.16.3",
     "adaptivecards-templating": "1.0.0-rc.0",
     "antlr4ts": "^0.5.0-alpha.3",
     "assert": "^2.0.0",

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -42,10 +42,12 @@ export class ChoiceSetInput extends React.Component {
 		this.payload = props.json;
 		this.label = Constants.EmptyString;
 		this.isRequired = this.payload.isRequired || false;
-		this.placeholder = this.payload.placeholder
+		this.placeholder = this.payload.placeholder;
+		this.pickerRef = React.createRef();
+
 
 		this.state = {
-			selectedPickerValue: this.payload.value,
+			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value)) && this.payload.value,
 			isPickerSelected: false,
 			radioButtonIndex: undefined,
 			activeIndex: undefined,
@@ -53,6 +55,10 @@ export class ChoiceSetInput extends React.Component {
 			checkedValues: undefined,
 			isError: this.isRequired ? this.validate() : false
 		}
+	}
+
+	componentDidUpdate() {
+		Platform.OS === Constants.PlatformAndroid && this.state.isPickerSelected && this.pickerRef?.current?.focus?.();
 	}
 
 	/**
@@ -183,6 +189,7 @@ export class ChoiceSetInput extends React.Component {
 					onPress={onPress}
 					accessible={true}
 					accessibilityRole={'button'}
+					accessibilityLabel={this.getPickerSelectedValue(this.state.selectedPickerValue, addInputItem)}
 					accessibilityState={{ expanded: this.state.isPickerSelected }}
 				>
 					<View style={this.styleConfig.dropdown}>
@@ -210,9 +217,16 @@ export class ChoiceSetInput extends React.Component {
 		let picker = (
 			<Picker
 				mode={'dropdown'}
+				ref={this.pickerRef}
+				enabled={false}
 				style={(Platform.OS === Constants.PlatformAndroid) && { width: '100%', height: '100%', position: 'absolute', opacity: 0 }}
+				onFocus={() => {
+					this.setState({
+						isPickerSelected: false
+					})
+				}}
 				itemStyle={this.styleConfig.picker}
-				selectedValue={this.getPickerInitialValue(addInputItem)}
+				selectedValue={this.getPickerInitialValue(addInputItem) || (this.payload.choices[0]?.value)}
 				onValueChange={
 					(itemValue) => {
 						this.setState({

--- a/source/community/reactnative/yarn.lock
+++ b/source/community/reactnative/yarn.lock
@@ -1390,10 +1390,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
-"@react-native-picker/picker@^1.9.11":
-  version "1.9.11"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.9.11.tgz#490c752417c17d687e2941659b3c0bff9cb79b83"
-  integrity sha512-E7whvvMIl9Ln1sxgug7OAEVWQ69n82iV0d2OWWp5VV52+RW3azKh1IFm4rxdW5/oByMfl7FFL0eHNelGgY4BMQ==
+"@react-native-picker/picker@^1.16.3":
+  version "1.16.8"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-1.16.8.tgz#2126ca54d4a5a3e9ea5e3f39ad1e6643f8e4b3d4"
+  integrity sha512-pacdQDX6V6EmjF+HoiIh6u++qx4mTK0WnhgUHRc01B+Qt5eoeUwseBqmqfTSXTx/aHDEd6PiIw7UGvKgFoqgFQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"


### PR DESCRIPTION
### Description

This PR fixes accessibility for choice set(compact) style in Android which was introduced as part of https://github.com/BigThinkcode/AdaptiveCards/pull/58.

### Issue:
- For compact style choice set, it renders custom element containing textbox with placeholder/default/selected value with dropdown image and hides the default picker element which shows its own text box in Android. On picker element selected, it shows the dropdown with list of choices.
- In case of Android, the custom element was not accessible when talkback was switched on and as a result, functionality was affected.

### Fix: 
- Initializing selected value only in case of valid value present in the payload else, it used to call render function twice and change the selectedPickerValue. Due to this, wrong values were seen earlier when talkback was switched on.
- Used onFocus and focus method to programmatically open and close the dropdown and disabled the picker in case of Android. onFocus and enabled props are specific to Android platform only and available as part of 1.16.3 version.


### How Verified

https://user-images.githubusercontent.com/25148603/150842407-05541013-9fcc-46ef-a431-341005ffe00c.mp4

https://user-images.githubusercontent.com/25148603/150840864-17300679-521c-45f1-a666-8b0145b44f5e.mp4





