### PR TITLE
Add data prop to custom actions

### DIFF
--- a/source/community/reactnative/src/components/actions/action-button.js
+++ b/source/community/reactnative/src/components/actions/action-button.js
@@ -120,6 +120,7 @@ export class ActionButton extends React.Component {
 				this.onToggleActionCalled();
 				break;
 			default:
+				actionPayload.data = this.getMergeObject();
 				//Invoked for the custom action type.
 				this.onExecuteAction(actionPayload);
 				break;


### PR DESCRIPTION
# Description

For Custom Actions in a form payload, `data` prop is not passed in the same way as in `submit` action. When custom action is clicked, all data entered by user in form fields is lost as no state is saved. 
In this PR, adding `data` prop for custom actions. No change for other scenarios/props.

# Screenshots
![image](https://user-images.githubusercontent.com/72800429/153055847-16e0d717-2ca8-40e2-9283-f6007e922ef2.png)


![image](https://user-images.githubusercontent.com/72800429/153055880-f7eb4aa8-cf1f-4ce3-9ea5-f40038f73251.png)

