### PR TITLE
label wrap, input default value

### DIFF
--- a/source/community/reactnative/src/components/elements/label.js
+++ b/source/community/reactnative/src/components/elements/label.js
@@ -19,7 +19,7 @@ export class Label extends React.Component {
 	render() {
 		this.hostConfig = this.props.configManager.hostConfig;
 
-		let { text, altText, wrap, maxLines, onDidLayout } = this.props;
+		let { text, altText, wrap, maxLines, onDidLayout, isRequired } = this.props;
 
 		// parse & format DATE/TIME values
 		let lang = this.context.lang;
@@ -29,7 +29,7 @@ export class Label extends React.Component {
 		let receivedStyle = this.props.style;
 
 		// compute style from props
-		let computedStyle = this.getComputedStyle();
+		const [computedStyle, extraStyles] = this.getComputedStyle();
 
 		// number of lines
 		let numberOfLines = wrap ? (maxLines != undefined ? maxLines : 0) : 1;
@@ -40,8 +40,10 @@ export class Label extends React.Component {
 		return (
 			<MarkDownFormatter
 				defaultStyles={[computedStyle, receivedStyle]}
+				extraStyles={extraStyles}
 				numberOfLines={numberOfLines}
 				text={formattedText}
+				isRequired={!!isRequired}
 				altText={altText}
 				onDidLayout={onDidLayout}
 				{...clickProps} />
@@ -104,13 +106,18 @@ export class Label extends React.Component {
 			Enums.TextSize.Default
 		));
 
-		return {
+		// required asterisk style
+		const requiredTextStyle = this.hostConfig.getTextColorForStyle(Enums.TextColor.Attention, Enums.ContainerStyle.Default);
+
+		return [{
 			fontSize,
 			fontWeight: fontWeight.toString(),
 			fontFamily: fontFamilyValue,
 			color: colorValue,
 			textAlign,
 			lineHeight
-		}
+		}, {
+			requiredTextStyle
+		}];
 	}
 }

--- a/source/community/reactnative/src/components/inputs/input-label.js
+++ b/source/community/reactnative/src/components/inputs/input-label.js
@@ -15,7 +15,7 @@ export default class InputLabel extends React.Component {
 	constructor(props) {
 		super(props);
 		this.label = props.label || Constants.EmptyString;
-		this.wrap = props.wrap || false;
+		this.wrap = props.wrap || true;
 		this.style = props.style || {};
 		this.isRequired = props.isRequired || false;
 		this.hostConfig = props.configManager.hostConfig;
@@ -24,7 +24,7 @@ export default class InputLabel extends React.Component {
 	}
 
 	render() {
-		const { label, wrap, style, applyStyleConfig } = this;
+		const { label, isRequired, wrap, style, applyStyleConfig } = this;
 
 		// NOTE :: Do not apply label styles on Toggle, other Input's labels style is picked from themeconfig
 		let computedStyle = style;
@@ -41,6 +41,7 @@ export default class InputLabel extends React.Component {
 						style={[this.props.configManager.styleConfig.defaultFontConfig, computedStyle]}
 						configManager={this.props.configManager}
 						wrap={wrap}
+						isRequired={!!isRequired}
 						altText={this.props.altText} />
 				);
 			} else if (typeof label == Constants.TypeObject && this.isValidLabelType(label.type)) {
@@ -55,7 +56,6 @@ export default class InputLabel extends React.Component {
 			return (
 				<View style={styles.container} accessible={typeof label == Constants.TypeString ? true: undefined}>
 					<View>{inputLabel}</View>
-					{this.isRequired && this.getRedAsterisk()}
 				</View>
 			);
 		} else return inputLabel;
@@ -64,19 +64,10 @@ export default class InputLabel extends React.Component {
 	isValidLabelType = type => {
 		return !isNullOrEmpty(type) && (type == Constants.TypeTextBlock || type == Constants.TypeRichTextBlock);
 	}
-
-	getRedAsterisk = () => {
-		const colorDefinition = this.hostConfig.getTextColorForStyle(TextColor.Attention, ContainerStyle.Default);
-		return (<Text style={[styles.redAsterisk, { color: colorDefinition.default }]}>*</Text>);
-	}
 }
 
 const styles = StyleSheet.create({
 	container: {
 		flexDirection: Constants.FlexRow
-	},
-	redAsterisk: {
-		marginLeft: 2,
-		alignSelf: Constants.CenterString
 	}
 });

--- a/source/community/reactnative/src/components/inputs/input.js
+++ b/source/community/reactnative/src/components/inputs/input.js
@@ -121,7 +121,7 @@ export class Input extends React.Component {
 		const { isMultiline } = this;
 
 		// remove placeholderTextColor from styles object before using
-		const { placeholderTextColor, activeColor, inactiveColor, singleLineHeight, multiLineHeight, ...stylesObject } = this.styleConfig.input;
+		const { placeholderTextColor, placeholderCursorColor, activeColor, inactiveColor, singleLineHeight, multiLineHeight, ...stylesObject } = this.styleConfig.input;
 		let inputComputedStyles = [stylesObject, styles.input];
 		inputComputedStyles.push({ borderColor: this.state.isFocused ? activeColor : inactiveColor })
 		isMultiline ?

--- a/source/community/reactnative/src/components/inputs/text-input.js
+++ b/source/community/reactnative/src/components/inputs/text-input.js
@@ -27,8 +27,8 @@ export class InputText extends React.Component {
 		this.regex = this.payload.regex ? new RegExp(this.payload.regex) : undefined;
 
 		this.state = {
-			isError: this.isRequired,
-			text:  this.payload.value ? this.payload.value : Constants.EmptyString
+			isError: this.isInvalid(this.payload.value),
+			text: this.payload.value ? this.payload.value : Constants.EmptyString
 		}
 	}
 
@@ -79,13 +79,19 @@ export class InputText extends React.Component {
 	/**
 	 * @description validate the text in the textInput field based on style of the textInput.
 	 */
-	validate = () => {
+	validate = (textValue) => {
+		this.setState({
+			isError: this.isInvalid(textValue)
+		})
+	};
+
+	isInvalid = (textValue) => {
 		let isError = false;
 		if (this.isRequired) {
 			isError = true;
 		}
-		
-		let text = this.state.text.trim();
+
+		let text = textValue?.trim();
 		if (text) {
 			if (Utils.isNullOrEmpty(this.regex)) {
 				switch (this.styleValue) {
@@ -109,7 +115,8 @@ export class InputText extends React.Component {
 				isError = !this.regex.test(text);
 			}
 		}
-		this.setState({ isError });
+
+		return isError;
 	};
 
 	/**
@@ -126,8 +133,8 @@ export class InputText extends React.Component {
 	 */
 	handleBlur = () => {
 		if (this.isRequired)
-			this.validate();
+			this.validate(this.state.text);
 		else if (this.regex)
-			this.validate();
+			this.validate(this.state.text);
 	}
 }

--- a/source/community/reactnative/src/utils/markdown-formatter.js
+++ b/source/community/reactnative/src/utils/markdown-formatter.js
@@ -20,6 +20,7 @@ export default class MarkdownFormatter extends React.PureComponent {
 	matchesStyles = [];
 
 	text = '';
+	isRequired = false;
 	patterns = [];
 	styles = [];
 	styleTypes = [];
@@ -82,7 +83,9 @@ export default class MarkdownFormatter extends React.PureComponent {
 
 		this.numberOfLines = props.numberOfLines;
 		this.userStyles = props.defaultStyles;
+		this.extraStyles = props.extraStyles;
 		this.text = props.text;
+		this.isRequired = props.isRequired;
 		this.altText = props.altText;
 		this.regexArray = this.MD_FORMATTER_CONFIG;
 
@@ -92,7 +95,9 @@ export default class MarkdownFormatter extends React.PureComponent {
 	render() {
 		this.numberOfLines = this.props.numberOfLines;
 		this.userStyles = this.props.defaultStyles;
+		this.extraStyles = this.props.extraStyles;
 		this.text = this.props.text;
+		this.isRequired = this.props.isRequired;
 		this.altText = this.props.altText;
 		this.matchedIndices = [];
 		this.matchesFound = [];
@@ -106,10 +111,10 @@ export default class MarkdownFormatter extends React.PureComponent {
 
 		return (
 			this.altText ?
-			<View accessible={true} accessibilityLabel={this.altText}>
-				{this.renderText(this.text)}
-			</View> :
-			this.renderText(this.text)
+				<View accessible={true} accessibilityLabel={this.altText}>
+					{this.renderText(this.text)}
+				</View> :
+				this.renderText(this.text)
 		);
 	}
 
@@ -244,7 +249,7 @@ export default class MarkdownFormatter extends React.PureComponent {
 		if (this.matchesFound.length < 1) {
 			jsxArray.push(
 				<Text key={'text'} style={this.userStyles} numberOfLines={this.numberOfLines}>
-					{remainingText}
+					{remainingText}{!!this.isRequired && this.getRedAsterisk()}
 				</Text>
 			);
 		} else {
@@ -335,6 +340,12 @@ export default class MarkdownFormatter extends React.PureComponent {
 		return jsxArray;
 	}
 
+	getRedAsterisk = () => {
+		return (
+			<Text style={[{ color: this.extraStyles?.requiredTextStyle?.default }]}> *</Text>
+		);
+	}
+
 	/**
 	 * @description Create the actual <Text/> elements
 	 * @returns {Array} fullJsx - Array of created elements
@@ -422,13 +433,13 @@ export default class MarkdownFormatter extends React.PureComponent {
 	}
 
 	/**
-     * @description Finds the nth Index for Fact key and column value.
+	 * @description Finds the nth Index for Fact key and column value.
 	 * @param {Array} arr - Input array
 	 * @param {} - element
 	 * @param {number} nthIndex
 	 * 
 	 * @return {number} index
-     */
+	 */
 	findNthIndexOfElement(arr, element, nthIndex) {
 		var index = -1;
 		for (var i = 0, len = arr.length; i < len; i++) {

--- a/source/community/reactnative/src/visualizer/payloads/payloads/Input.Label.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/Input.Label.json
@@ -19,6 +19,14 @@
         "isRequired": true
       },
       {
+        "type": "Input.Text",
+        "style": "text",
+        "label": "Long Label test to verify label wrapping along with required field test. This text should wrap, not truncate, and end with asterisk",
+        "id": "LongLabelVal",
+        "errorMessage": "Required",
+        "isRequired": true
+      },
+      {
         "type": "Input.Number",
         "id": "Phone",
         "label": {


### PR DESCRIPTION
# Description

Add input label wrap for long texts. Moved required asterisk to MarkdownFormatter to bring it in line with long text.
Fix input field validation error when default value is present.

# Sample Card

Added long label test in Input.label.json (screenshot below)

# How Verified

#### iOS
<img src="https://user-images.githubusercontent.com/72800429/155464369-bd6fc020-51a8-40e5-867f-d63298448b76.png" width="350" height="100" />

#### Android
<img src="https://user-images.githubusercontent.com/72800429/155470254-993ca3e9-5155-4c79-82c9-8eb492cf9171.png" width="350" height="100" />


| iOS Old | iOS New | Android Old | Android New |
| ----------- | ----------- | ----------- | ----------- |
| <img src="https://user-images.githubusercontent.com/72800429/155464613-8d0d8b45-aa5c-4665-b027-7c9dd6e4b914.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155464830-9c733c87-8397-4e57-9e83-7ecf54ff324a.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155470454-292547bb-78e0-4651-9f74-7a1ab0196b32.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155470384-9bf46a8e-5675-4c48-bb7a-fe7093ba4bf8.png" width="450" height="180" /> |
| <img src="https://user-images.githubusercontent.com/72800429/155464962-4f91f854-3eb6-4aef-8d5b-84c9cf1cef41.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155465056-109e4b21-e423-4d78-8ee1-69b39cfa655f.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155470648-d489fb81-8c88-4dea-a067-3bb280e04e57.png" width="450" height="180" /> | <img src="https://user-images.githubusercontent.com/72800429/155470708-be56f20e-10b4-47ff-b536-0d1f97b82e0f.png" width="450" height="180" /> | 

