### PR TITLE
Removed the package react-native-windows

### DIFF
--- a/source/community/reactnative/package.json
+++ b/source/community/reactnative/package.json
@@ -54,7 +54,6 @@
     "antlr4ts": "^0.5.0-alpha.3",
     "assert": "^2.0.0",
     "react-native-video": "^4.4.2",
-    "react-native-windows": "0.57.1",
     "react-native-keyboard-aware-scroll-view": "^0.9.5"
   },
   "jest": {


### PR DESCRIPTION
Removed the package react-native-windows.

Tested the updated package on the iOS platform.

@pragadeeshk @vivekvijayakrishnan @Zaidos9 - Please test the same on the Android platform.