### PR TITLE
Fixed visualizer build issue for android

### DIFF
--- a/source/community/reactnative/android/app/build.gradle
+++ b/source/community/reactnative/android/app/build.gradle
@@ -139,7 +139,7 @@ android {
         versionCode 1
         versionName "1.1"
         ndk {
-            abiFilters "armeabi-v7a", "x86"
+            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }
     signingConfigs {

--- a/source/community/reactnative/android/app/src/main/AndroidManifest.xml
+++ b/source/community/reactnative/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
+	  android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
# Related Issue

Visualizer App not running

# Description

The Visualizer App does not start as expected by following steps listed in the following [README](https://github.com/BigThinkcode/AdaptiveCards/tree/fork-main/source/community/reactnative#examples--visualizer). Metro is started. Running Android emulator. 
Getting following error:
Unable to load script. Make sure you're either running a Metro server (run 'react-native start') or that your bundle 'index.android.bundle' is packaged correctly for release.


