### PR TITLE
Hariksingh/reactnative picker fix

### DIFF
--- a/source/community/reactnative/package.json
+++ b/source/community/reactnative/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adaptivecards-reactnative",
   "description": "AdaptiveCards implementation in ReactNative",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "keywords": [
     "adaptivecards",
     "cards",
@@ -47,7 +47,7 @@
     "react-native": "0.68.2",
     "react-test-renderer": "16.13.1",
     "rnpm-plugin-windows": "^0.2.11",
-	"patch-package": "^6.4.7"
+    "patch-package": "^6.4.7"
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "^6.0.2",

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -216,7 +216,7 @@ export class ChoiceSetInput extends React.Component {
 		let picker = (
 			<Picker
 				mode={'dropdown'}
-				style={(Platform.OS === Constants.PlatformAndroid) && { width: '100%', height: '100%', position: 'absolute', opacity: 0 }}
+				style={(Platform.OS === Constants.PlatformAndroid) && { width: '100%', height: '100%', position: 'absolute', opacity: 0, accessible: false }}
 				itemStyle={this.styleConfig.picker}
 				selectedValue={this.getPickerInitialValue(addInputItem)}
 				onValueChange={

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -43,9 +43,9 @@ export class ChoiceSetInput extends React.Component {
 		this.label = Constants.EmptyString;
 		this.isRequired = this.payload.isRequired || false;
 		this.placeholder = this.payload.placeholder;
-
+		this.pickerRef = React.createRef();
 		this.state = {
-			selectedPickerValue: this.payload.value,
+			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value)) && this.payload.value,
 			isPickerSelected: false,
 			radioButtonIndex: undefined,
 			activeIndex: undefined,
@@ -54,7 +54,10 @@ export class ChoiceSetInput extends React.Component {
 			isError: this.isRequired ? this.validate() : false
 		}
 	}
-
+	
+	componentDidUpdate() {
+		Platform.OS === Constants.PlatformAndroid && this.state.isPickerSelected && this.pickerRef?.current?.focus?.();
+	}
 	/**
 	 * @description Parse hostConfig specific to this element
 	 */
@@ -184,6 +187,7 @@ export class ChoiceSetInput extends React.Component {
                         onPress={onPress}
                         accessible={true}
                         accessibilityRole={'button'}
+						accessibilityLabel={this.getPickerSelectedValue(this.state.selectedPickerValue, addInputItem)}
                         accessibilityState={{
                             expanded: this.state.isPickerSelected,
                         }}>
@@ -216,9 +220,16 @@ export class ChoiceSetInput extends React.Component {
 		let picker = (
 			<Picker
 				mode={'dropdown'}
+				ref={this.pickerRef}
+				enabled={false}
 				style={(Platform.OS === Constants.PlatformAndroid) && { width: '100%', height: '100%', position: 'absolute', opacity: 0, accessible: false }}
+				onFocus={() => {
+					this.setState({
+						isPickerSelected: false
+					})
+				}}
 				itemStyle={this.styleConfig.picker}
-				selectedValue={this.getPickerInitialValue(addInputItem)}
+				selectedValue={this.getPickerInitialValue(addInputItem) || (this.payload.choices[0]?.value)}
 				onValueChange={
 					(itemValue) => {
 						this.setState({

--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -45,7 +45,7 @@ export class ChoiceSetInput extends React.Component {
 		this.placeholder = this.payload.placeholder;
 		this.pickerRef = React.createRef();
 		this.state = {
-			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value)) && this.payload.value,
+			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value)),
 			isPickerSelected: false,
 			radioButtonIndex: undefined,
 			activeIndex: undefined,


### PR DESCRIPTION
This PR fixes accessibility for choice set(compact) style in Android

Issue:
For compact style choice set, it renders custom element containing textbox with placeholder/default/selected value with dropdown image and hides the default picker element which shows its own text box in Android. On picker element selected, it shows the dropdown with list of choices.
In case of Android, the custom element was not accessible when talkback was switched on and as a result, functionality was affected.
https://user-images.githubusercontent.com/113006406/189971565-a380bf13-c040-4cb2-a356-b15c3c0373cd.mov

Fix:
https://user-images.githubusercontent.com/113006406/189971504-aed4e72d-b93b-4d2c-bf02-4049f52cca71.mov

Initialising selected value only in case of valid value present in the payload else, it used to call render function twice and change the selectedPickerValue. Due to this, wrong values were seen earlier when talkback was switched on.
Used onFocus and focus method to programmatically open and close the dropdown and disabled the picker in case of Android. onFocus and enabled props are specific to Android platform only and available as part of 1.16.3 version.