### PR TITLE
Hariksingh/fix select action quick view

### DIFF
--- a/source/community/reactnative/src/components/actions/select-Action.js
+++ b/source/community/reactnative/src/components/actions/select-Action.js
@@ -50,8 +50,8 @@
 		 for (const key in this.inputArray) {
 			 mergedObject[key] = this.inputArray[key].value;
 		 }
-		 if (actionPayload !== null) {
-			 if (actionPayload instanceof Object) {
+		 if (actionPayload !== null && actionPayload.data !== null) {
+			 if (actionPayload.data instanceof Object) {
 				 mergedObject = { ...mergedObject, ...actionPayload.data }
 				 actionPayload.data = mergedObject;
 			 }

--- a/source/community/reactnative/src/components/actions/select-Action.js
+++ b/source/community/reactnative/src/components/actions/select-Action.js
@@ -19,7 +19,6 @@
  
 	 constructor(props) {
 		 super(props);
- 
 		 this.payload = this.props.selectActionData;
 		 this.onExecuteAction = undefined;
 		 this.inputArray = undefined;
@@ -61,16 +60,16 @@
 				 break;
 		 }
 	 }
-	 getMergeObject = () => {
+	 getMergeObject = (payload) => {
 		 let mergedObject = {};
 		 for (const key in this.inputArray) {
 			 mergedObject[key] = this.inputArray[key].value;
 		 }
-		 if (this.data !== null) {
+		 if (payload !== null) {
 			 if (this.data instanceof Object)
-				 mergedObject = { ...mergedObject, ...this.data }
+				 mergedObject = { ...mergedObject, ...payload }
 			 else
-				 mergedObject["actionData"] = this.data;
+				 mergedObject["actionData"] = payload;
 		 }
 		 return mergedObject;
 	 }
@@ -82,7 +81,6 @@
 		 this.payload = this.props.selectActionData;
 		 this.onExecuteAction = undefined;
 		 this.toggleVisibilityForElementWithID = undefined;
- 
 		 const ButtonComponent = TouchableOpacity;
 		 return (<InputContextConsumer>
 			 {({ onExecuteAction, inputArray, addResourceInformation, toggleVisibilityForElementWithID }) => {

--- a/source/community/reactnative/src/components/actions/select-Action.js
+++ b/source/community/reactnative/src/components/actions/select-Action.js
@@ -1,7 +1,6 @@
 /**
  * SelectAction Component.
  */
-
  import React from 'react';
  import {
 	 TouchableOpacity,
@@ -12,35 +11,22 @@
  } from '../../utils/context';
  import * as Constants from '../../utils/constants';
  import * as Utils from '../../utils/util';
- 
  export class SelectAction extends React.Component {
- 
 	 static contextType = InputContext;
- 
 	 constructor(props) {
 		 super(props);
 		 this.payload = this.props.selectActionData;
 		 this.onExecuteAction = undefined;
-		 this.inputArray = undefined;
 		 this.toggleVisibilityForElementWithID = undefined;
+		 this.inputArray = undefined;
 		 this.addResourceInformation = undefined;
 	 }
- 
 	 /**
 	  * @description Invoked on tapping the button component
 	  */
 	 onClickHandle() {
 		 let actionPayload = { ... this.payload };
 		 switch (actionPayload.type) {
-			 case Constants.ActionSubmit:
-			 case Constants.ActionExecute:
-				 actionPayload.data = this.getMergeObject();
-				 /*
-				  actionPayload already has `ignoreInputValidation` but to support 
-				  backward compatibility we are passing it explicitly
-				 **/
-				 this.onExecuteAction(actionPayload, actionPayload.ignoreInputValidation);
-				 break;
 			 case Constants.ActionOpenUrl:
 				 if (!Utils.isNullOrEmpty(this.props.selectActionData.url)) {
 					 actionPayload.url = this.props.selectActionData.url;
@@ -54,38 +40,36 @@
 				 //As per the AC schema, ShowCard action type is not supported by selectAction.
 				 if (actionPayload.type != Constants.ActionShowCard) {
 					 //Pass complete payload for all other types. 
-					 actionPayload.data = this.getMergeObject();
-					 this.onExecuteAction(actionPayload);
+					 this.onExecuteAction(this.getMergeObject(actionPayload));
 				 }
 				 break;
 		 }
 	 }
-	 getMergeObject = (payload) => {
+	 getMergeObject = (actionPayload) => {
 		 let mergedObject = {};
 		 for (const key in this.inputArray) {
 			 mergedObject[key] = this.inputArray[key].value;
 		 }
-		 if (payload !== null) {
-			 if (this.data instanceof Object)
-				 mergedObject = { ...mergedObject, ...payload }
-			 else
-				 mergedObject["actionData"] = payload;
+		 if (actionPayload !== null) {
+			 if (actionPayload instanceof Object) {
+				 mergedObject = { ...mergedObject, ...actionPayload.data }
+				 actionPayload.data = mergedObject;
+			 }
 		 }
-		 return mergedObject;
+		 return actionPayload;
 	 }
 	 render() {
 		 if (!this.props.configManager.hostConfig.supportsInteractivity) {
 			 return null;
 		 }
- 
 		 this.payload = this.props.selectActionData;
 		 this.onExecuteAction = undefined;
 		 this.toggleVisibilityForElementWithID = undefined;
 		 const ButtonComponent = TouchableOpacity;
 		 return (<InputContextConsumer>
 			 {({ onExecuteAction, inputArray, addResourceInformation, toggleVisibilityForElementWithID }) => {
-				 this.inputArray = inputArray;
 				 this.onExecuteAction = onExecuteAction;
+				 this.inputArray = inputArray;
 				 this.addResourceInformation = addResourceInformation;
 				 this.toggleVisibilityForElementWithID = toggleVisibilityForElementWithID;
 				 return <ButtonComponent
@@ -103,5 +87,3 @@
 		 </InputContextConsumer>);
 	 }
  }
- 
- 


### PR DESCRIPTION
#Issue:
Quick views were not opening when user clicked on the adaptive card,

#Fix 
Added input parameter  actionPayload in local function getMergeObject.

#How Verified

Platform | Before | After
-|-|-
ios | https://user-images.githubusercontent.com/113006406/193199279-879ea591-c435-432d-8ed8-eab28bb3910a.MP4|https://user-images.githubusercontent.com/113006406/193197685-cdc934f5-6ec6-44ad-a735-7fc1492d16e7.mp4
android | https://user-images.githubusercontent.com/113006406/193237591-b403202f-392d-4f19-9a26-a65d99f776aa.mp4 | https://user-images.githubusercontent.com/113006406/193237839-68043aac-1b51-47e7-b0ff-44d7e0c9cf43.mp4

