### PR TITLE
Fixed Choice Set Issue: On Submit action Choice modal returned when no value is selected in choice set.

### DIFF
--- a/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/choice-set-input.js
@@ -45,7 +45,7 @@ export class ChoiceSetInput extends React.Component {
 		this.placeholder = this.payload.placeholder;
 		this.pickerRef = React.createRef();
 		this.state = {
-			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value)),
+			selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value))  && this.payload.value,
 			isPickerSelected: false,
 			radioButtonIndex: undefined,
 			activeIndex: undefined,


### PR DESCRIPTION
Issue:
When no value is selected in choice set, selectedPickerValue is coming as choiceModal object.

Fix:
Updated && this.payload.value in below line.

selectedPickerValue: (this.payload.choices.find(choice => choice.value === this.payload.value))  && this.payload.value, 

Issue:

https://user-images.githubusercontent.com/113006406/200355567-f6a45c35-b737-4dfd-a24a-2c425504bbd6.MP4


