### PR TITLE
Added maxFontSizeMultiplier prop to Action button

### DIFF
--- a/source/community/reactnative/package.json
+++ b/source/community/reactnative/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adaptivecards-reactnative",
   "description": "AdaptiveCards implementation in ReactNative",
-  "version": "2.2.31",
+  "version": "2.2.32",
   "keywords": [
     "adaptivecards",
     "cards",

--- a/source/community/reactnative/src/components/actions/action-button.js
+++ b/source/community/reactnative/src/components/actions/action-button.js
@@ -226,7 +226,10 @@ export class ActionButton extends React.Component {
                         style={[styles.buttonIcon, this.styleConfig.actionIcon]}
                     />
                 ) : null}
-                <Text numberOfLines={1} style={this.getButtonTitleStyles()}>
+                <Text 
+					numberOfLines={1}
+					maxFontSizeMultiplier={this.props.maxFontSizeMultiplier}
+					style={this.getButtonTitleStyles()}>
                     {this.title}
                 </Text>
             </View>


### PR DESCRIPTION
# Related Issue
[Feature Request] Limit Max Scale for Action Button

the issue fixed with this PR - https://github.com/BigThinkcode/AdaptiveCards/issues/113

# Description

Provide maxFontSizeMultiplier as a property to ActionButton component to control the max scaling size of the Action button label. This is not part of the payload. This will be used when Action button is used in the host application by importing manually.