### PR TITLE
Migrated ViewPropTypes to deprecated-react-native-prop-types 

### DIFF
--- a/source/community/reactnative/package.json
+++ b/source/community/reactnative/package.json
@@ -56,7 +56,8 @@
     "antlr4ts": "^0.5.0-alpha.3",
     "assert": "^2.0.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-video": "^5.2.0"
+    "react-native-video": "^5.2.0",
+		"deprecated-react-native-prop-types":"^2.3.0"
   },
   "jest": {
     "preset": "react-native",

--- a/source/community/reactnative/src/components/inputs/choice-set/check-box.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/check-box.js
@@ -3,12 +3,12 @@
  */
 
 import React from 'react';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types'
 import {
 	View,
 	Text,
 	TouchableOpacity,
-	StyleSheet,
-	ViewPropTypes,
+	StyleSheet
 } from 'react-native';
 import { Label } from '../../elements'
 import PropTypes from 'prop-types';


### PR DESCRIPTION
# Related Issue

View PropTypes is deprecated, need to migrate to another library
https://github.com/facebook/react-native/issues/33557

# Description

ViewPropTypes is deprecated and we have to migrate to deprecated view prop types untill we completely eliminate it.

# Sample Card

NA

# How Verified
