### PR TITLE
Fix up deprecated Text.propType usage

### DIFF
--- a/source/community/reactnative/src/components/inputs/choice-set/check-box.js
+++ b/source/community/reactnative/src/components/inputs/choice-set/check-box.js
@@ -9,7 +9,7 @@ import {
 	TouchableOpacity,
 	StyleSheet,
 } from 'react-native';
-import { ViewPropTypes } from 'deprecated-react-native-prop-types';
+import { ViewPropTypes, TextPropTypes } from 'deprecated-react-native-prop-types';
 import { Label } from '../../elements'
 import PropTypes from 'prop-types';
 import * as Constants from '../../../utils/constants';
@@ -50,7 +50,7 @@ class CheckBox extends React.PureComponent {
 		checked: PropTypes.bool,
 		wrapText: PropTypes.bool,
 		isRadioButtonType: PropTypes.bool,
-		labelStyle: Text.propTypes.style,
+		labelStyle: TextPropTypes.style,
 		iconSize: PropTypes.number,
 	};
 


### PR DESCRIPTION
# Related Issue
Not an issue but related to PRs
https://github.com/BigThinkcode/AdaptiveCards/pull/120
https://github.com/BigThinkcode/AdaptiveCards/pull/119

# Description
This was missed in the other PRs around now deprecated prop type declarations, Text.propTypes was also removed from the core react-native library but for some reason doesn't throw an exception if used like View.proptypes and the others, itll just cause the app to crash when it tries to access the prop.

Solution is the same as the other PRs here and utelises the deprecated-react-native-prop-types library

# How Verified
I have a local fork with all three PRs in place, without this change my app crashes as soon as it tries to render an adaptive card because it tries to access the now removes prop, with this PR it does not and everything works again.
