### PR TITLE
Adding a Prop keyboardAvoidingViewEnabled 

### DIFF
--- a/source/community/reactnative/src/adaptive-card.js
+++ b/source/community/reactnative/src/adaptive-card.js
@@ -248,7 +248,7 @@ export default class AdaptiveCard extends React.Component {
             </ContainerWrapper>
         );
 
-        if (!this.props.isActionShowCard) {
+        if (!this.props.isActionShowCard && this.props.keyboardAvoidingViewEnabled) {
 			adaptiveCardContent = (
                 <KeyboardAwareScrollView
                     enableOnAndroid={true}
@@ -359,9 +359,11 @@ AdaptiveCard.propTypes = {
 	contentHeight: PropTypes.number,
 	containerStyle: PropTypes.object,
 	contentContainerStyle: PropTypes.object,
-	cardScrollEnabled: PropTypes.bool
+	cardScrollEnabled: PropTypes.bool,
+	keyboardAvoidingViewEnabled: PropTypes.bool
 };
 
 AdaptiveCard.defaultProps = {
-	cardScrollEnabled: true
+	cardScrollEnabled: true,
+	keyboardAvoidingViewEnabled: true
 };


### PR DESCRIPTION
# Related Issue
[Rendering] Auto Scrolling due to KeyboardAvoidView #124 


# Description

Added a prop ```keyboardAvoidingViewEnabled``` to control the bahaviour. This is set to true by default for backward Compatability.

# Sample Card
Adding ScreenShots
| Normal | keyboard - Before | Keyboard - After|
|---|---|---|
| No Keyboard  |```keyboardAvoidingViewEnabled = true```|```keyboardAvoidingViewEnabled = false```|
|![image](https://github.com/BigThinkcode/AdaptiveCards/assets/48358526/26173440-1942-4f5f-8fe9-2a0dacf91f52)|![image](https://github.com/BigThinkcode/AdaptiveCards/assets/48358526/222c4209-4bbd-48ac-a549-5c423d9a434a)|![image](https://github.com/BigThinkcode/AdaptiveCards/assets/48358526/ccf01032-03f1-477e-91ff-8d1db7f2f17a)|

# How Verified
Manually tested in Client App by overriding the Prop

