### PR TITLE
Allowing no of lines to be changed from parent component

### DIFF
--- a/source/community/reactnative/src/components/actions/action-button.js
+++ b/source/community/reactnative/src/components/actions/action-button.js
@@ -227,7 +227,7 @@ export class ActionButton extends React.Component {
                     />
                 ) : null}
                 <Text 
-					numberOfLines={1}
+					numberOfLines={this.props.numberOfLines || 1}
 					maxFontSizeMultiplier={this.props.maxFontSizeMultiplier}
 					style={this.getButtonTitleStyles()}>
                     {this.title}


### PR DESCRIPTION
# Related Issue
[[Rendering] numberOfLines is hardcoded as 1 in action button #129](https://github.com/BigThinkcode/AdaptiveCards/issues/129)

# Description
allows number of lines to be changed from props

# Sample Card
-
# How Verified
tested locally on viva connections app

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
