### PR TITLE
Accessible nested actions within select-action

### DIFF
--- a/source/community/reactnative/src/adaptive-card.js
+++ b/source/community/reactnative/src/adaptive-card.js
@@ -222,7 +222,8 @@ export default class AdaptiveCard extends React.Component {
 
 		//If contentHeight is passed by the user from adaptive card via props, we will set this as height
 		this.props.contentHeight && containerStyles.push({ height: this.props.contentHeight })
-
+		const hasSelectAction = !Utils.isNullOrEmpty(this.payload.selectAction);
+		const disableActionsNestingInSelectAction = this.props.disableActionableControlsNestingOnRoot;
         var adaptiveCardContent = (
             <ContainerWrapper
                 configManager={this.configManager}
@@ -237,7 +238,7 @@ export default class AdaptiveCard extends React.Component {
                     alwaysBounceHorizontal={false}
                     scrollEnabled={this.props.cardScrollEnabled}>
                     {this.parsePayload()}
-                    {!Utils.isNullOrEmpty(this.state.cardModel.actions) && (
+                    {(!disableActionsNestingInSelectAction || (disableActionsNestingInSelectAction && !hasSelectAction)) && !Utils.isNullOrEmpty(this.state.cardModel.actions) && (
                         <ActionWrapper
                             configManager={this.configManager}
                             style={{marginHorizontal: padding}}
@@ -260,11 +261,25 @@ export default class AdaptiveCard extends React.Component {
 		}
 
 		// checks if selectAction option is available for adaptive card
-		if (!Utils.isNullOrEmpty(this.payload.selectAction)) {
+		if (hasSelectAction) {
 			adaptiveCardContent = (
-				<SelectAction configManager={this.configManager} selectActionData={this.payload.selectAction}>
-					{adaptiveCardContent}
-				</SelectAction>
+				<>
+					<SelectAction configManager={this.configManager} selectActionData={this.payload.selectAction}>
+						{adaptiveCardContent}
+					</SelectAction>
+					{disableActionsNestingInSelectAction && !Utils.isNullOrEmpty(this.state.cardModel.actions) && (
+						<View style={this.props.rootActionContainerStyle || {position: 'absolute', bottom: 0, width: '100%'}}>
+							<ActionWrapper
+								configManager={this.configManager}
+								style={{marginHorizontal: padding}}
+								actions={this.state.cardModel.actions}
+								deviceFontScale={this.props.deviceFontScale}
+				
+							/>
+						</View>
+					)}
+				</>
+
 			);
 		}
 		return adaptiveCardContent;
@@ -362,11 +377,14 @@ AdaptiveCard.propTypes = {
 	contentContainerStyle: PropTypes.object,
 	cardScrollEnabled: PropTypes.bool,
 	keyboardAvoidingViewEnabled: PropTypes.bool,
+	disableActionableControlsNestingOnRoot: PropTypes.bool,
+	rootActionContainerStyle: PropTypes.object,
 	deviceFontScale: PropTypes.number
 };
 
 AdaptiveCard.defaultProps = {
 	cardScrollEnabled: true,
 	keyboardAvoidingViewEnabled: true,
+	disableActionableControlsNestingOnRoot: false,
 	deviceFontScale: 1
 };


### PR DESCRIPTION
Nested interactive components are not read by screen readers. This PR fixes the simple case of accessibility on select action on root adaptive card object and an action set on the root body.
As per best guidelines, such components should not be nested.

# Description

For all Pull Requests, please describe how the issue was fixed or how the feature was implemented from a summary level. This information will be used to help provide context to the reviewers of the pull request and should be additive to the issue being closed.

# Sample Card

If appropriate, please include a link to a card in one of the samples directories that can be used to validate this change. This can be an existing card or a card added with this PR.

# How Verified

How you verified the fix, including one or all of the following:
1. New unit tests that were added if any. If none were added please add a quick line explaining why not.
2. Existing relevant unit/regression tests that you ran
3. Manual scenario verification if any; ***Do include .gif's or screenshots of the testing you performed here if you think that it
will aid in code reviews or corresponding fixes on other platforms for eg.***
